### PR TITLE
[PIRA-3] Fix AWS Batch job queue

### DIFF
--- a/nextflow/modules/batch/main.tf
+++ b/nextflow/modules/batch/main.tf
@@ -29,7 +29,7 @@ resource "aws_batch_job_queue" "nextflow" {
   job_state_time_limit_action {
     state            = "RUNNABLE"
     action           = "CANCEL"
-    reason           = "Timeout"
+    reason           = ""
     max_time_seconds = 600
   }
 


### PR DESCRIPTION
### Changes

<!-- High-level description of changes as topics -->

- Refactors the reason field to match the [template](https://docs.aws.amazon.com/batch/latest/userguide/job-queue-template.html).

### Comments (optional)

<!-- Add context, tag people, etc. as text -->

The error on [CI](https://github.com/andre-marcos-perez/pira-infra/actions/runs/16736881713/job/47377875740) is:

```
│ operation error Batch: CreateJobQueue, https response error StatusCode:
│ 400, RequestID: d59d3fa9-f911-46ad-830b-899c6586e51c, ClientException:
│ Invalid job reason.
```

### Checklist

Please make sure to check the following:

- [ ] Development completed according to the ticket;
- [ ] Feature is documented (Readme.md, docs, etc.);
- [ ] Unit and integration tests created;
- [ ] Tested on an integration environment.
