### PR TITLE
[PIRA-4] Fix AWS Batch job queue - II

### DIFF
--- a/nextflow/modules/batch/main.tf
+++ b/nextflow/modules/batch/main.tf
@@ -29,7 +29,7 @@ resource "aws_batch_job_queue" "nextflow" {
   job_state_time_limit_action {
     state            = "RUNNABLE"
     action           = "CANCEL"
-    reason           = ""
+    reason           = "CAPACITY:INSUFFICIENT_INSTANCE_CAPACITY"
     max_time_seconds = 600
   }
 


### PR DESCRIPTION
### Changes

<!-- High-level description of changes as topics -->

- Refactors the reason field to match the available reasons.

<img width="893" height="474" alt="image" src="https://github.com/user-attachments/assets/18e55db5-0262-45a4-ab76-1238d646a5c0" />

### Comments (optional)

<!-- Add context, tag people, etc. as text -->

The error on [CI](https://github.com/andre-marcos-perez/pira-infra/actions/runs/16737173621/job/47378306063) is:

```
│ operation error Batch: CreateJobQueue, https response error StatusCode:
│ 400, RequestID: 5dc1a375-7cf6-42b4-aeb4-27b776cd5919, ClientException: Job
│ reason cannot be empty.
```

### Checklist

Please make sure to check the following:

- [ ] Development completed according to the ticket;
- [ ] Feature is documented (Readme.md, docs, etc.);
- [ ] Unit and integration tests created;
- [ ] Tested on an integration environment.